### PR TITLE
Twig URL macro for referencing static assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,14 @@ With the example entry above, that output fill will be:
 
 Now you can load up your site, and should be able to enjoy all that vite has to offer. 
 
+
+### Static assets in Twig
+
+If you need to reference static assets from Twig, you can use the included `url` Twig macro:
+
+```twig
+{% import "_partials/vite" as vite %}
+<img src="{{ vite.url('images/foo.jpg') }}">
+```
+
+**Note:** This will only work for assets that are in the `publicDir` defined in your Vite config.

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -15,6 +15,7 @@ export default function craftPartials(options = {}) {
   );
 
   let config: ResolvedConfig;
+  let basePath: string;
   let proxyUrl: string;
 
   return {
@@ -23,7 +24,9 @@ export default function craftPartials(options = {}) {
     configResolved(resolvedConfig: ResolvedConfig) {
       config = resolvedConfig;
 
-      const { server } = config;
+      const { base, server } = config;
+
+      basePath = base;
       proxyUrl = `http://localhost:${server.port || 3000}`;
     },
 
@@ -38,7 +41,7 @@ export default function craftPartials(options = {}) {
 
       fs.writeFileSync(
         outputFile,
-        template({ scripts, links, meta, mode, proxyUrl })
+        template({ scripts, links, meta, basePath, mode, proxyUrl })
       );
     },
 
@@ -50,7 +53,7 @@ export default function craftPartials(options = {}) {
       }
 
       const { scripts, links, meta } = parseFile(html);
-      fs.writeFileSync(outputFile, template({ scripts, links, meta, mode }));
+      fs.writeFileSync(outputFile, template({ scripts, links, meta, basePath, mode, proxyUrl }));
     },
 
     closeBundle() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface ParsedHtml {
 }
 
 export interface TemplateParams extends Partial<ParsedHtml> {
+  basePath?: string;
   proxyUrl?: string;
   mode?: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,6 +48,7 @@ export function replaceAttribute(
  * @param scripts
  * @param links
  * @param meta
+ * @param basePath
  * @param proxyUrl
  * @param mode
  */
@@ -55,6 +56,7 @@ export function defaultTemplateFunction({
   scripts = [],
   links = [],
   meta = [],
+  basePath = "",
   proxyUrl = "",
   mode = "production",
 }: TemplateParams): string {
@@ -63,13 +65,15 @@ export function defaultTemplateFunction({
 
   let headString = `${meta.join('')}${linkTags.join('')}`;
   let endBody = `${scriptTags.join('')}`;
+  let rootPath = mode === "development" ? proxyUrl : basePath;
 
   if (mode === "development") {
     headString = `<script type="module" src="${proxyUrl}/@vite/client"></script>${headString}`;
   }
 
   return `
-  {% html at head %}${headString}{% endhtml %}
-  {% html at endBody %}${endBody}{% endhtml %}
-  `.trim();
+{%- macro url(path) -%}{{ '${rootPath}' | replace('/\\\\/$/', '') ~ '/' }}{{ path }}{%- endmacro -%}
+{% html at head %}${headString}{% endhtml %}
+{% html at endBody %}${endBody}{% endhtml %}
+`.trim();
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,7 +72,7 @@ export function defaultTemplateFunction({
   }
 
   return `
-{%- macro url(path) -%}{{ '${rootPath}' | replace('/\\\\/$/', '') ~ '/' }}{{ path }}{%- endmacro -%}
+{%- macro url(path) -%}{{ '${rootPath}' | replace('/\\\\/$/', '') }}{{ path }}{%- endmacro -%}
 {% html at head %}${headString}{% endhtml %}
 {% html at endBody %}${endBody}{% endhtml %}
 `.trim();

--- a/tests/__snapshots__/utils.test.ts.snap
+++ b/tests/__snapshots__/utils.test.ts.snap
@@ -1,13 +1,13 @@
 // Vitest Snapshot v1
 
 exports[`defaultTemplateFunction development mode 1`] = `
-"{%- macro url(path) -%}{{ 'http://localhost' | replace('/\\\\\\\\/$/', '') ~ '/' }}{{ path }}{%- endmacro -%}
+"{%- macro url(path) -%}{{ 'http://localhost' | replace('/\\\\\\\\/$/', '') }}{{ path }}{%- endmacro -%}
 {% html at head %}<script type=\\"module\\" src=\\"http://localhost/@vite/client\\"></script><link rel=\\"stylesheet\\" href=\\"http://localhost/src/styles/main.scss\\"><link rel=\\"stylesheet\\" href=\\"http://localhost/src/styles/test.scss\\">{% endhtml %}
 {% html at endBody %}<script type=\\"module\\" src=\\"http://localhost/src/scripts/main.js\\"></script>{% endhtml %}"
 `;
 
 exports[`defaultTemplateFunction production mode 1`] = `
-"{%- macro url(path) -%}{{ '/dist/' | replace('/\\\\\\\\/$/', '') ~ '/' }}{{ path }}{%- endmacro -%}
+"{%- macro url(path) -%}{{ '/dist/' | replace('/\\\\\\\\/$/', '') }}{{ path }}{%- endmacro -%}
 {% html at head %}<link rel=\\"stylesheet\\" href=\\"/src/styles/main.scss\\"><link rel=\\"stylesheet\\" href=\\"/src/styles/test.scss\\">{% endhtml %}
 {% html at endBody %}<script type=\\"module\\" src=\\"/src/scripts/main.js\\"></script>{% endhtml %}"
 `;

--- a/tests/__snapshots__/utils.test.ts.snap
+++ b/tests/__snapshots__/utils.test.ts.snap
@@ -1,11 +1,13 @@
 // Vitest Snapshot v1
 
 exports[`defaultTemplateFunction development mode 1`] = `
-"{% html at head %}<script type=\\"module\\" src=\\"/@vite/client\\"></script><link rel=\\"stylesheet\\" href=\\"/src/styles/main.scss\\"><link rel=\\"stylesheet\\" href=\\"/src/styles/test.scss\\">{% endhtml %}
-  {% html at endBody %}<script type=\\"module\\" src=\\"/src/scripts/main.js\\"></script>{% endhtml %}"
+"{%- macro url(path) -%}{{ 'http://localhost' | replace('/\\\\\\\\/$/', '') ~ '/' }}{{ path }}{%- endmacro -%}
+{% html at head %}<script type=\\"module\\" src=\\"http://localhost/@vite/client\\"></script><link rel=\\"stylesheet\\" href=\\"http://localhost/src/styles/main.scss\\"><link rel=\\"stylesheet\\" href=\\"http://localhost/src/styles/test.scss\\">{% endhtml %}
+{% html at endBody %}<script type=\\"module\\" src=\\"http://localhost/src/scripts/main.js\\"></script>{% endhtml %}"
 `;
 
 exports[`defaultTemplateFunction production mode 1`] = `
-"{% html at head %}<link rel=\\"stylesheet\\" href=\\"/src/styles/main.scss\\"><link rel=\\"stylesheet\\" href=\\"/src/styles/test.scss\\">{% endhtml %}
-  {% html at endBody %}<script type=\\"module\\" src=\\"/src/scripts/main.js\\"></script>{% endhtml %}"
+"{%- macro url(path) -%}{{ '/dist/' | replace('/\\\\\\\\/$/', '') ~ '/' }}{{ path }}{%- endmacro -%}
+{% html at head %}<link rel=\\"stylesheet\\" href=\\"/src/styles/main.scss\\"><link rel=\\"stylesheet\\" href=\\"/src/styles/test.scss\\">{% endhtml %}
+{% html at endBody %}<script type=\\"module\\" src=\\"/src/scripts/main.js\\"></script>{% endhtml %}"
 `;

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -30,7 +30,7 @@ test("replaceAttribute", () => {
 
 test("defaultTemplateFunction production mode", () => {
   const { scripts, links } = parseFile(TEST_HTML);
-  const result = defaultTemplateFunction({ scripts, links });
+  const result = defaultTemplateFunction({ scripts, links, basePath: "/dist/" });
 
   expect(result).toMatchSnapshot();
 });
@@ -41,6 +41,7 @@ test("defaultTemplateFunction development mode", () => {
     scripts,
     links,
     mode: "development",
+    proxyUrl: "http://localhost",
   });
 
   expect(result).toMatchSnapshot();


### PR DESCRIPTION
@brianjhanson Not sure how you feel about this approach to #2 in general, but I've tested it and it seems to check all of the boxes I have:

- [x] Doesn't require a separate Craft plugin
- [x] Allows you to use the same file paths in both Twig and CSS - e.g. `'/fonts/work-sans.woff'`
- [x] Works in both development and build
- [x] Preloading of fonts in Twig works (when the fonts are actually imported in CSS)
- [x] Easy to reason about, and you can see the entirety of the logic behind it just by popping open `vite.twig`
- [x] Nice syntax (aside from the need to `import` the macro, which I can live with)