### PR TITLE
Customizable base dev server address

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A [vite](https://vitejs.dev/) plugin that that allows you to use vite with Craft
 
 ## General Approach
 
-The plugin parses the `index.html` file created by Vite and generates a Craft twig partial from it. This way we get all benefits of the smart peoeple working on Vite without adding a lot of overhead.
+The plugin parses the `index.html` file created by Vite and generates a Craft twig partial from it. This way we get all benefits of the smart people working on Vite without adding a lot of overhead.
 
 ## Basic Usage
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,14 +2,14 @@ import fs from "fs";
 import path from "path";
 import { Plugin, ResolvedConfig } from "vite";
 import { defaultTemplateFunction, parseFile } from "./utils";
-import { NormalizedInputOptions } from "rollup";
 
 export default function craftPartials(options = {}) {
-  const { outputFile, template } = Object.assign(
+  const { outputFile, template, devServerBaseAddress } = Object.assign(
     {},
     {
       outputFile: "./templates/_partials/vite.twig",
       template: defaultTemplateFunction,
+      devServerBaseAddress: "http://localhost",
     },
     options
   );
@@ -27,7 +27,7 @@ export default function craftPartials(options = {}) {
       const { base, server } = config;
 
       basePath = base;
-      proxyUrl = `http://localhost:${server.port || 3000}`;
+      proxyUrl = `${devServerBaseAddress}:${server.port || 3000}`;
     },
 
     buildStart({ input }: any) {


### PR DESCRIPTION
I'm going to go ahead and advocate that we do this. No one has to use it if they don't want to - and in that case nothing user-facing about the plugin changes - but it provides an escape hatch for situations where you need to use an alternate host or protocol, the most pressing example of which is proxying the site on a network device.