### PR TITLE
Legacy Plugin Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ npm i -D vite-plugin-craftcms
 ### Create your entry file
 
 ```html
-<link rel="stylesheet" href="./styles/main.scss" />
-<script type="module" src="./scripts/main.js"></script>
+<head>
+  <link rel="stylesheet" href="./styles/main.scss">
+</head>
+<body>
+  <script type="module" src="./scripts/main.js"></script>
+</body>
 ```
 
-This should be an HTML fragment located in your `./src` directory. The asset paths within this file should be relative to the file. 
+This should be an HTML fragment located in your `./src` directory with a name that matches `rollupOptions.input` in your `vite.config`. The asset paths within this file should be relative to the file. 
 
 ### Add the plugin to your `vite.config` file.
 
@@ -74,7 +78,7 @@ export default defineConfig(({ command, mode }) => {
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Craft Vite Boilerplate</title>
+  <title>Craft Vite</title>
 </head>
 
 <body>
@@ -86,7 +90,7 @@ export default defineConfig(({ command, mode }) => {
 ```
 ### Start it up
 
-A file will be generated in the location specified by the `outputFile` option. The default template function collects all the `meta` and `link` elements and wraps them in `{% html at head %}` in order to inject them into the head. While `script` tags are added at the end of the body. 
+A file will be generated in the location specified by the `outputFile` option. The default template function collects all `script` and `link` elements and wraps them in either `{% html at head %}` or `{% html at endBody %}` in order to inject them into the `<head>` or `<body>`.
 
 It will also replace all your relative URLs with URLs to the vite proxy server.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "rollup": "^2.70.1",
         "typescript": "^4.6.3",
         "unbuild": "^0.7.2",
+        "vite": "^2.9.8",
         "vite-plugin-inspect": "^0.4.3",
         "vitest": "^0.9.2"
       },
@@ -1920,6 +1921,7 @@
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.32.tgz",
       "integrity": "sha512-RuzVUP/bkStmnVHK6Gh3gjaMjfXNLqBqvYVDiS9JKl5KdRdRLUeW5Wo8NrbL7cL6CW7Cyak7SvACqyPOBuA8vA==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -1957,6 +1959,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1972,6 +1975,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1987,6 +1991,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2002,6 +2007,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2017,6 +2023,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2032,6 +2039,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2047,6 +2055,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2062,6 +2071,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2077,6 +2087,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2092,6 +2103,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2107,6 +2119,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2122,6 +2135,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2137,6 +2151,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2152,6 +2167,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2167,6 +2183,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -2182,6 +2199,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -2197,6 +2215,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -2212,6 +2231,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2227,6 +2247,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2242,6 +2263,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2654,6 +2676,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -2666,7 +2689,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -2867,6 +2891,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -3375,6 +3400,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
       "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -4788,9 +4814,10 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-      "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -5593,7 +5620,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -5622,7 +5650,8 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -5727,9 +5756,10 @@
       "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
+      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5741,7 +5771,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.1",
+        "nanoid": "^3.3.3",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -6017,6 +6047,7 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -6110,6 +6141,7 @@
       "version": "2.70.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
       "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+      "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -6326,6 +6358,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6468,6 +6501,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6888,12 +6922,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.1.tgz",
-      "integrity": "sha512-vSlsSdOYGcYEJfkQ/NeLXgnRv5zZfpAsdztkIrs7AZHV8RCMZQkwjo4DS5BnrYTqoWqLoUe1Cah4aVO4oNNqCQ==",
+      "version": "2.9.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.8.tgz",
+      "integrity": "sha512-zsBGwn5UT3YS0NLSJ7hnR54+vUKfgzMUh/Z9CxF1YKEBVIe213+63jrFLmZphgGI5zXwQCSmqIdbPuE8NJywPw==",
+      "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
-        "postcss": "^8.4.12",
+        "postcss": "^8.4.13",
         "resolve": "^1.22.0",
         "rollup": "^2.59.0"
       },
@@ -8592,6 +8627,7 @@
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.32.tgz",
       "integrity": "sha512-RuzVUP/bkStmnVHK6Gh3gjaMjfXNLqBqvYVDiS9JKl5KdRdRLUeW5Wo8NrbL7cL6CW7Cyak7SvACqyPOBuA8vA==",
+      "dev": true,
       "requires": {
         "esbuild-android-64": "0.14.32",
         "esbuild-android-arm64": "0.14.32",
@@ -8619,120 +8655,140 @@
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.32.tgz",
       "integrity": "sha512-q1qjB2UcoWehR9Yp9dO2RdJUeLLrXAYsbOU4tkYa+GmJzxTwuvOrMdvaemsXYqb7F4STVTca9KpfqGicEChtUg==",
+      "dev": true,
       "optional": true
     },
     "esbuild-android-arm64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.32.tgz",
       "integrity": "sha512-bs1uu+RuM15f8yjFc0FhPDE/6NID4fKl7beDVsGCme6Q8ld2IzRXmp5QaHurlcH93PFyQnUgVvdahIWgtK2QZw==",
+      "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.32.tgz",
       "integrity": "sha512-6MekflAld28wYtzanwZTxQlxMPeYw/yv1ToFG2hpo3LGxOIE2mBD5IJaMCcyy1//EYvGnGToO3p6XKdbS8E1QQ==",
+      "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.32.tgz",
       "integrity": "sha512-BHYIjiPDYQTD+4zwqdqRo+I2bbg3fn9mah/gZm4SCCy+7uwTTYOYobIunHT7wVCgxnFCr50PJUdaMrEoCImRbw==",
+      "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.32.tgz",
       "integrity": "sha512-6BOBhtfAf9AlfjL1AvtfVOxwY82tHPfYrA0lskJpFjfiEMGTLU6e0vdOwb4+4x++gGz49azuGK0woYqdfL03uw==",
+      "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.32.tgz",
       "integrity": "sha512-zIRR4gKQW56p/xLM8TlpxVBNiX0w3VoR9ZxfH4nrfJ7QiL0SYHRy8YPL5C7zMWRjSze2WxQRHfS9bHKdVrVXBw==",
+      "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.32.tgz",
       "integrity": "sha512-kn0AkGtPvzA6xiv93/mavvZ7DVinu/ewh2F2S0/8mE8/PXi3D4+svZ6V3beV5DIH7vcHVuGhoooWav8HPF04tg==",
+      "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.32.tgz",
       "integrity": "sha512-Ie+PMvrPj/HCOmSc0QubKttDxP2iBtPzDu+b+V3HGDGwkGmVpDkyXx1NXp5LjkIphIay2QekMwy1dSw3KDqCew==",
+      "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.32.tgz",
       "integrity": "sha512-R/Bvn/YQNDyvfN0SERh/I7hKPqN+nSSruQdVeiYEJ+jc3fUi73jXYAscpTQgIBeER/yXnEsgJGU/UQ9+sscr7A==",
+      "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.32.tgz",
       "integrity": "sha512-ykoqKaxX95nB+lk2K/+qxr0ke+BxkeVi0yKOnymCR5Ive7IZDHa4BJX53NEGSBKLfWPwKE6SXTz8qcEewSntoA==",
+      "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.32.tgz",
       "integrity": "sha512-IilnlBexpHpt/5po0cle/L/S6CYnwaq23UuAqWzxp+opHLOCNnyANpC1jOoP551aRx4JuZ7z3xZZ7bYQZB147w==",
+      "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.32.tgz",
       "integrity": "sha512-TR6l5nWZbfq7jSY+1vsiQjT4m67NWplNhbX6GBieZq6DBt0nTx1XgTZAdKROF7jTuaK7YrCYlPXtfO3w86Mysw==",
+      "dev": true,
       "optional": true
     },
     "esbuild-linux-riscv64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.32.tgz",
       "integrity": "sha512-aSOcUzTeIAslfri8e+bMpyzQuxhcIiNhWyuCGGXum2PtxwYiUqR8/UCMYfwYtYkhr1yABOFOfs83mm9KBy5qCQ==",
+      "dev": true,
       "optional": true
     },
     "esbuild-linux-s390x": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.32.tgz",
       "integrity": "sha512-dNlip+EvexxKjRZitFCWCd7DVk64c7R5ySr8aFEMHCb/RriNiyDxYJGzYWm4EMJsMRMupMUHlMY64BAa3Op9FA==",
+      "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.32.tgz",
       "integrity": "sha512-Pa3QByYqxzlBFQQQhjYBPg3WUfSjwibqzh1hC6mPDRUHnCeUcrLoBuIiG4xqOYEpQM9/kDowIBsrGIQEVWWdQA==",
+      "dev": true,
       "optional": true
     },
     "esbuild-openbsd-64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.32.tgz",
       "integrity": "sha512-uWKKqpCjkMY8TCIobFvaSETonQY3OrmgnoTCC3tF+lvMoneYjppB6akx7L5Xv0kP+1tnSbrIof1ca8PfqGUyjw==",
+      "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.32.tgz",
       "integrity": "sha512-Ar+u3mBk0oVV4Fwv/qlinJZNIPPtTBSG+1W42o8lOaVxJ+rJgecDoeUN+5uyd9at0BK1SVrQ1qZ4wjHKB0qFpQ==",
+      "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.32.tgz",
       "integrity": "sha512-rLMsbflMY6Hjh3rmQnCDVZahJQ7n+XfT6o1+no5pHRpDlMh38MHthgGh35q+EcOMgrGP3ppnw70rhJq80SaYTQ==",
+      "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.32.tgz",
       "integrity": "sha512-OHnMMxYufVgLXIMnwLynLMKguHMrsVnWcehieSP9i6ZX31KEsOFYWrorcnTWOn4rbZVLSL10ofxLuVIgRW3SWw==",
+      "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
       "version": "0.14.32",
       "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.32.tgz",
       "integrity": "sha512-ddavy6IPUBySMfqDfG243TgtuqwQBNJQJPVaA4DaavmMfpBsUxFrSV+HzBWXTKU3I9EcuoEvIATLuQ7NJKxjwg==",
+      "dev": true,
       "optional": true
     },
     "escalade": {
@@ -9044,12 +9100,14 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -9192,6 +9250,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -9593,6 +9652,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
       "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -10601,9 +10661,10 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-      "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -11198,7 +11259,8 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -11221,7 +11283,8 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.1",
@@ -11297,11 +11360,12 @@
       }
     },
     "postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
+      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
+      "dev": true,
       "requires": {
-        "nanoid": "^3.3.1",
+        "nanoid": "^3.3.3",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -11496,6 +11560,7 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -11563,6 +11628,7 @@
       "version": "2.70.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
       "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+      "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -11706,7 +11772,8 @@
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
     },
     "sourcemap-codec": {
       "version": "1.4.8",
@@ -11818,7 +11885,8 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "symbol-observable": {
       "version": "3.0.0",
@@ -12134,13 +12202,14 @@
       }
     },
     "vite": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.1.tgz",
-      "integrity": "sha512-vSlsSdOYGcYEJfkQ/NeLXgnRv5zZfpAsdztkIrs7AZHV8RCMZQkwjo4DS5BnrYTqoWqLoUe1Cah4aVO4oNNqCQ==",
+      "version": "2.9.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.8.tgz",
+      "integrity": "sha512-zsBGwn5UT3YS0NLSJ7hnR54+vUKfgzMUh/Z9CxF1YKEBVIe213+63jrFLmZphgGI5zXwQCSmqIdbPuE8NJywPw==",
+      "dev": true,
       "requires": {
         "esbuild": "^0.14.27",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.12",
+        "postcss": "^8.4.13",
         "resolve": "^1.22.0",
         "rollup": "^2.59.0"
       }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "rollup": "^2.70.1",
     "typescript": "^4.6.3",
     "unbuild": "^0.7.2",
+    "vite": "^2.9.8",
     "vite-plugin-inspect": "^0.4.3",
     "vitest": "^0.9.2"
   },

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -63,6 +63,10 @@ export default function craftPartials(options = {}) {
       })
     },
 
+    async buildEnd(error) {
+      if (error) throw error;
+    },
+
     closeBundle() {
       console.log("Removing src files in dist ...");
       const outputPath = path.resolve(

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -19,7 +19,8 @@ export default function craftPartials(options = {}) {
   let proxyUrl: string;
 
   return {
-    name: "twig:test",
+    name: "craftcms",
+    enforce: 'post',
 
     configResolved(resolvedConfig: ResolvedConfig) {
       config = resolvedConfig;
@@ -37,24 +38,28 @@ export default function craftPartials(options = {}) {
       }
 
       const inputFile = fs.readFileSync(input);
-      const { scripts, links, meta } = parseFile(inputFile.toString());
+      const { head, body} = parseFile(inputFile.toString());
 
       fs.writeFileSync(
         outputFile,
-        template({ scripts, links, meta, basePath, mode, proxyUrl })
+        template({ head, body, basePath, mode, proxyUrl })
       );
     },
 
-    transformIndexHtml(html: string) {
-      const { mode } = config;
+    transformIndexHtml: {
+      enforce: 'post',
+      transform(html: string) {
+        const { mode } = config;
 
-      if (mode !== "production") {
-        return;
-      }
+        if (mode !== "production") {
+          return;
+        }
 
-      const { scripts, links, meta } = parseFile(html);
-      fs.writeFileSync(outputFile, template({ scripts, links, meta, basePath, mode, proxyUrl }));
+        const { head, body} = parseFile(html);
+        fs.writeFileSync(outputFile, template({ head, body, basePath, mode, proxyUrl }));
+      },
     },
+
 
     closeBundle() {
       console.log("Removing src files in dist ...");

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -20,7 +20,7 @@ export default function craftPartials(options = {}) {
 
   return {
     name: "craftcms",
-    enforce: 'post',
+    enforce: "post",
 
     configResolved(resolvedConfig: ResolvedConfig) {
       config = resolvedConfig;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -46,20 +46,22 @@ export default function craftPartials(options = {}) {
       );
     },
 
-    transformIndexHtml: {
-      enforce: 'post',
-      transform(html: string) {
-        const { mode } = config;
+    writeBundle(_, bundle) {
+      const { mode } = config;
 
-        if (mode !== "production") {
-          return;
+      if (mode !== "production") {
+        return;
+      }
+
+      Object.keys(bundle).forEach(name => {
+        const asset = bundle[name];
+        if (asset.fileName.match(/\.html$/) && 'source' in asset) {
+          console.log(`Generating ${asset.fileName} template...`)
+          const { head, body} = parseFile(asset.source.toString());
+          fs.writeFileSync(outputFile, template({ head, body, basePath, mode, proxyUrl }));
         }
-
-        const { head, body} = parseFile(html);
-        fs.writeFileSync(outputFile, template({ head, body, basePath, mode, proxyUrl }));
-      },
+      })
     },
-
 
     closeBundle() {
       console.log("Removing src files in dist ...");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,8 @@
 import { HTMLElement } from "node-html-parser";
 
 export interface ParsedHtml {
-  scripts: HTMLElement[];
-  links: HTMLElement[];
-  meta: HTMLElement[];
+  head: HTMLElement[];
+  body: HTMLElement[];
 }
 
 export interface TemplateParams extends Partial<ParsedHtml> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ function isValidElement(item: any): boolean {
  */
 export function parseFile(html: string): ParsedHtml {
   const root = parse(html);
-  const headEl = root.querySelector("head");
+  const headEl = root.querySelector("head") ?? root;
   const bodyEl = root.querySelector("body");
 
   const head = <HTMLElement[]>headEl?.childNodes.filter(isValidElement);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,6 @@ import { HTMLElement, parse } from "node-html-parser";
 import { ParsedHtml, TemplateParams } from "./types";
 
 function isValidElement(item: any): boolean {
-  console.log(item);
   return item instanceof HTMLElement
     && [
       "script",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,11 +2,9 @@ import { HTMLElement, parse } from "node-html-parser";
 import { ParsedHtml, TemplateParams } from "./types";
 
 function isValidElement(item: any): boolean {
+  const validElements = ["script", "link"];
   return item instanceof HTMLElement
-    && [
-      "script",
-      "link",
-    ].includes(item.tagName);
+    && (validElements.includes(item.tagName) || validElements.includes(item.rawTagName));
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,14 @@
 import { HTMLElement, parse } from "node-html-parser";
 import { ParsedHtml, TemplateParams } from "./types";
 
-function isValidElement(item: any): boolean {
+/**
+ * Determines whether a given element should be included in the output.
+ * @param {HTMLElement|Node} element The element to check.
+ */
+function isElementIncluded(element: any): boolean {
   const validElements = ["script", "link"];
-  return item instanceof HTMLElement
-    && (validElements.includes(item.tagName) || validElements.includes(item.rawTagName));
+  return element instanceof HTMLElement
+    && (validElements.includes(element.tagName) || validElements.includes(element.rawTagName));
 }
 
 /**
@@ -15,8 +19,8 @@ export function parseFile(html: string): ParsedHtml {
   const headEl = root.querySelector("head") ?? root;
   const bodyEl = root.querySelector("body");
 
-  const head = <HTMLElement[]>headEl?.childNodes.filter(isValidElement);
-  const body = <HTMLElement[]>bodyEl?.childNodes.filter(isValidElement);
+  const head = <HTMLElement[]>headEl?.childNodes.filter(isElementIncluded);
+  const body = <HTMLElement[]>bodyEl?.childNodes.filter(isElementIncluded);
 
   return {
     head,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,8 +67,8 @@ export function defaultTemplateFunction({
   proxyUrl = "",
   mode = "production",
 }: TemplateParams): string {
-  // const scriptTags = replaceAttribute(scripts, "src", "./", `${proxyUrl}/src/`);
-  // const linkTags = replaceAttribute(links, "href", "./", `${proxyUrl}/src/`);
+  replaceAttribute(head.concat(body), "src", "./", `${proxyUrl}/src/`);
+  replaceAttribute(head.concat(body), "href", "./", `${proxyUrl}/src/`);
 
   // Create a string from HTML elements
   let headString = head.map((element) => element.outerHTML).join("");

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -6,40 +6,43 @@ import {
 } from "../src/utils";
 
 const TEST_HTML = `
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="./styles/main.scss">
-<link rel="stylesheet" href="./styles/test.scss">
-<script type="module" src="./scripts/main.js"></script>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="./styles/main.scss">
+  <link rel="stylesheet" href="./styles/test.scss">
+</head>
+<body>
+  <script type="module" src="./scripts/main.js"></script>
+</body>
 `;
 
 test("parseFile", () => {
-  const { scripts, links, meta } = parseFile(TEST_HTML);
+  const { head, body } = parseFile(TEST_HTML);
 
-  expect(scripts).toHaveLength(1);
-  expect(links).toHaveLength(2);
-  expect(meta).toHaveLength(1);
+  expect(head).toHaveLength(2);
+  expect(body).toHaveLength(1);
 });
 
 test("replaceAttribute", () => {
-  const { scripts } = parseFile(TEST_HTML);
+  const { body } = parseFile(TEST_HTML);
 
-  const result = replaceAttribute(scripts, "src", "./", "http://localhost/");
+  const result = replaceAttribute(body, "src", "./", "http://localhost/");
   const expected = `<script type="module" src="http://localhost/scripts/main.js"></script>`;
   expect(result.toString()).toContain(expected);
 });
 
 test("defaultTemplateFunction production mode", () => {
-  const { scripts, links } = parseFile(TEST_HTML);
-  const result = defaultTemplateFunction({ scripts, links, basePath: "/dist/" });
+  const { head, body } = parseFile(TEST_HTML);
+  const result = defaultTemplateFunction({ head, body, basePath: "/dist/" });
 
   expect(result).toMatchSnapshot();
 });
 
 test("defaultTemplateFunction development mode", () => {
-  const { scripts, links } = parseFile(TEST_HTML);
+  const { head, body } = parseFile(TEST_HTML);
   const result = defaultTemplateFunction({
-    scripts,
-    links,
+    head,
+    body,
     mode: "development",
     proxyUrl: "http://localhost",
   });


### PR DESCRIPTION
Spent a good chunk of time working on this and (with some help from an absolute saint in the Vite Discord) was able to figure out what is going on here.

Unfortunately, using the `transformIndexHtml` hook doesn't work with `plugin-legacy` and possibly other similar plugins. However, using the `writeBundle` hook you can get access to transformed versions of all files in the pipeline, pluck out the HTML file, and parse that to get the same end result. That, along with setting `enforce: 'post'` on our plugin, will ensure that our plugin runs after legacy and gets access to all of it's modifications. So that's step one.

The next issue is that supporting plugins like legacy requires that you know where legacy expects each individual file to go in the final output, and you can't easily predict this just based on the file type - for instance, legacy puts some `script` tags in the `<head>` and some in the `<body>`, but it also puts some `link` tags in both places.

To handle this, we _could_ have a separate function for parsing HTML in development and production, but after thinking it over it seemed like there are some advantages to expecting an `entry.html` file to have it's files wrapped in `<head>` and `<body>` and not much of a downside.

The biggest advantage - aside from not needing a separate parsing approach in dev and build - is that it gives the user an easy way to control where these files will end up in Twig. For instance, I personally prefer for my main styles to be in the `head` and block render, but someone else might not want that, because they're using Critical CSS or whatever. This gives them a very easy, intuitive way to control that.

I like where this ended up. It doesn't add much code, the code isn't gross, and it gives me a lot more peace of mind knowing that if a project requires legacy it'll be easy to drop in.

Resolves #1 