### PR TITLE
Automatically use https for devServerBaseAddress.

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -9,7 +9,7 @@ export default function craftPartials(options = {}) {
     {
       outputFile: "./templates/_partials/vite.twig",
       template: defaultTemplateFunction,
-      devServerBaseAddress: "http://localhost",
+      devServerBaseAddress: "localhost",
     },
     options
   );
@@ -27,8 +27,9 @@ export default function craftPartials(options = {}) {
 
       const { base, server } = config;
 
+      const protocol = config.server.https ? 'https' : 'http';
       basePath = base;
-      proxyUrl = `${devServerBaseAddress}:${server.port || 3000}`;
+      proxyUrl = `${protocol}://${devServerBaseAddress}:${server.port || 3000}`;
     },
 
     buildStart({ input }: any) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -27,8 +27,8 @@ export default function craftPartials(options = {}) {
 
       const { base, server } = config;
 
-      const protocol = config.server.https ? 'https' : 'http';
       basePath = base;
+      const protocol = config.server.https ? 'https' : 'http';
       proxyUrl = `${protocol}://${devServerBaseAddress}:${server.port || 3000}`;
     },
 


### PR DESCRIPTION
This is technically a breaking change due to the removal of protocol in `devServerBaseAddress` so probably should throw something in the Release notes for that.

I think with this we can probably consider #8 resolved since the only other steps involved to get HTTPs working are handling the certificate and setting the `hmr`, but maybe worth documenting the steps to get that working in the README? I'm not sure.